### PR TITLE
Fix channel update listener

### DIFF
--- a/server_src/CacheManager.ts
+++ b/server_src/CacheManager.ts
@@ -31,12 +31,13 @@ class CacheManager {
     setupChannelUpdateListener() {
         const channelEvents = ["channelCreate", "channelDelete", "channelUpdate"];
 
+        client.on("voiceStateUpdate", (oldState) => {
+            this.needsChannelsUpdate.add(oldState.guild.id);
+        });
+
         for (const event of channelEvents) {
-            client.on("voiceStateUpdate", (oldState) => {
-                this.needsChannelsUpdate.add(oldState.guild.id);
-            });
             client.on(event, async (channel) => {
-                if (channel.type === "GUILD_TEXT" || channel.type === "GUILD_VOICE") {
+                if (channel.type === ChannelType.GuildText || channel.type === ChannelType.GuildVoice) {
                     this.needsChannelsUpdate.add(channel.guild.id);
                     this.debug ? logger.log("info", `Channels of ${channel.guild.name} needs to be updated`) : null;
                 }


### PR DESCRIPTION
## Summary
- fix cache update listener by using correct ChannelType constants
- prevent adding multiple `voiceStateUpdate` listeners

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2a83ef88325b6ac397b822077e3